### PR TITLE
Add allowed_networks config array

### DIFF
--- a/config_default.json
+++ b/config_default.json
@@ -417,5 +417,6 @@
     "url": {
         "ip": "0.0.0.0",
         "port": 5000
-    }
+    },
+    "allowed_networks": []
 }

--- a/main_server.py
+++ b/main_server.py
@@ -1287,7 +1287,7 @@ def check_local_network():
                 return
             
         return (
-            "Unauthorized access: you are not on the same network as the server." + ip_remote,
+            "Unauthorized access: you are not on the same network as the server.",
             403,
         )
 

--- a/main_server.py
+++ b/main_server.py
@@ -1281,8 +1281,13 @@ def check_local_network():
     # print(f'new connection established: {remote_ip}')
     
     if ip_remote != ip_local:
+        # check if in allowed network list in config
+        for network in config["allowed_networks"]:
+            if ipaddress.IPv4Address(remote_ip) in ipaddress.IPv4Network(network):
+                return
+            
         return (
-            "Unauthorized access: you are not on the same network as the server.",
+            "Unauthorized access: you are not on the same network as the server." + ip_remote,
             403,
         )
 


### PR DESCRIPTION
Hi there,

I noticed while trying to use WebDeck on a device in a separate VLAN (192.168.20.x), it could not connect as the `check_local_network` function explicitly only allows remote IPs from the the local network that WebDeck is located on. (192.168.1.x)

I modified `check_local_network` such that it checks if the remote IP matches any networks in the `allowed_networks` array located in the config JSON. It is an optional config array (left it empty in `config_default.json`), but if it exists, the check function will see if the remote IP matches any of the allowed network entries in the array before returning a 403 on requests.

This allowed me to access WebDeck from my device in the VLAN mentioned above, once I added the VLAN network to the `allowed_networks` array. Example of the array's usage:

```json
    "allowed_networks": [
        "192.168.20.0/24"
    ]
```