### PR TITLE
Add OBS hotkey function

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1597,6 +1597,36 @@
     }
   },
   "OBS Studio": {
+    "hotkey": {
+      "command": "/obs_key",
+      "args": [
+        {
+          "TYPE": "input text",
+          "en": "Key name",
+          "fr": "Nom de la clé",
+          "ko": "키 이름"
+        }
+      ],
+      "name": {
+        "en": "Hotkey",
+        "fr": "raccourci clavier",
+        "ko": "단축키"
+      },
+      "description": {
+        "en": "Trigger a hotkey in OBS",
+        "fr": "Déclencher un raccourci clavier dans OBS",
+        "ko": "OBS에서 핫키 트리거"
+      },
+      "style": {
+        "image": "obs_logo2.svg",
+        "image_size": "70%",
+        "name": {
+          "en": "OBS Hotkey",
+          "fr": "Raccourci clavier OBS",
+          "ko": "OBS 단축키"
+        }
+      }
+    },
     "changeScene": {
       "command": "/obs_scene",
       "args": [

--- a/main_server.py
+++ b/main_server.py
@@ -2546,6 +2546,13 @@ def send_data(message=None):
                 print("Virtual cam is already stopped.")
                 return jsonify({"success": False, "message": text["obs_no_vcam"]})
 
+        elif message.startswith("/obs_key"):
+            hotkey=message.split(' ')[-1]
+            result = obs.call(obsrequests.TriggerHotkeyByKeySequence(keyId="OBS_KEY_"+hotkey))
+            print("Hotkey triggered successfully.")
+            if "failed" in str(result):
+                return jsonify({"success": False, "message": f"{text['failed']} :/"})
+
         obs.disconnect()
         
     else:

--- a/main_server.py
+++ b/main_server.py
@@ -2549,9 +2549,10 @@ def send_data(message=None):
         elif message.startswith("/obs_key"):
             hotkey=message.split(' ')[-1]
             result = obs.call(obsrequests.TriggerHotkeyByKeySequence(keyId="OBS_KEY_"+hotkey))
-            print("Hotkey triggered successfully.")
             if "failed" in str(result):
+                print("ERROR:      ", result)
                 return jsonify({"success": False, "message": f"{text['failed']} :/"})
+            print("Hotkey triggered successfully.")
 
         obs.disconnect()
         


### PR DESCRIPTION
This PR adds a new command that directly calls a hotkey function in OBS via websocket, which dramatically expands controls available via WebDeck and fixes issues with OBS not detecting keys sent by WebDeck when not in focus or when running games that capture all input. Please note that the translations in this PR are done via Google Translate as I don't speak French or Korean.