### PR TITLE
Fix Open website button

### DIFF
--- a/main_server.py
+++ b/main_server.py
@@ -1826,7 +1826,7 @@ def send_data(message=None):
     elif message.startswith(("/openfile", "/start")):
         path = message.replace("/openfile", "", 1).replace("/start", "", 1).strip()
 
-        if ":" in path:
+        if "://" not in path and ":" in path:
             initial_path = os.getcwd()
             try:
                 file_directory = os.path.dirname(path)


### PR DESCRIPTION
This PR is a quick and dirty fix for https://github.com/Lenochxd/WebDeck/issues/30, which is caused by the "Open website" button using the `/start` command and going into the code path for opening files with absolute paths.