### PR TITLE
Load/store config through dedicated functions

### DIFF
--- a/app/buttons/usage/asked_devices.py
+++ b/app/buttons/usage/asked_devices.py
@@ -1,5 +1,6 @@
 import re
 import json
+from app.utils.settings.get_config import get_config
 
 
 def extract_asked_device(input_string):
@@ -9,8 +10,7 @@ def extract_asked_device(input_string):
 def get_asked_devices():
     devices = []
     
-    with open(".config/config.json", encoding="utf-8") as f:
-        config = json.load(f)
+    config = get_config()
     
     for folder_id, value in config["front"]["buttons"].items():
         for button in config["front"]["buttons"][folder_id]:

--- a/app/buttons/usage/get_usage.py
+++ b/app/buttons/usage/get_usage.py
@@ -5,6 +5,7 @@ import GPUtil
 import pynvml
 
 from app.utils.settings.get_config import get_config
+from app.utils.settings.save_config import save_config
 from app.utils.merge_dicts import merge_dicts
 from .asked_devices import get_asked_devices
 from app.utils.logger import log
@@ -88,8 +89,7 @@ def get_usage(get_all=None, asked_devices=[]):
                 computer_info["gpus"]["defaultGPU"] = {}
                 
                 config["settings"]["gpu_method"] = "None"
-                with open(".config/config.json", "w", encoding="utf-8") as json_file:
-                    json.dump(config, json_file, indent=4)
+                save_config(config)
                     
         elif config["settings"]["gpu_method"] == "nvidia (GPUtil)":
 

--- a/app/on_start/utils.py
+++ b/app/on_start/utils.py
@@ -12,6 +12,7 @@ from win32com.client import Dispatch
 
 from app.updater import check_files, check_for_updates
 from app.utils.settings.get_config import get_config
+from app.utils.settings.save_config import save_config
 from app.utils.global_variables import set_global_variable
 from app.utils.plugins.load_plugins import load_plugins
 from app.utils.get_local_ip import get_local_ip
@@ -61,8 +62,7 @@ def sort_colorsjson():
             json.dump(sorted_colors, f, indent=4)
             
 def get_gpu_method():
-    with open(".config/config.json", "r", encoding="utf-8") as f:
-        config = json.load(f)
+    config = get_config()
     
     if not "gpu_method" in config["settings"]:
         config["settings"]["gpu_method"] = "nvidia (pynvml)"
@@ -72,8 +72,8 @@ def get_gpu_method():
         except pynvml.NVMLError:
             config["settings"]["gpu_method"] = "AMD"
                 
-    with open(".config/config.json", "w", encoding="utf-8") as json_file:
-        json.dump(config, json_file, indent=4)
+                
+    save_config(config)
         
     return config
 
@@ -186,8 +186,7 @@ def on_start():
     if config["url"]["ip"] == "local_ip":
         config["url"]["ip"] = local_ip
         
-        with open(".config/config.json", "w", encoding="utf-8") as json_file:
-            json.dump(config, json_file, indent=4)
+        save_config(config)
     
     # Run threaded tasks
     on_start_threaded(config)

--- a/app/server.py
+++ b/app/server.py
@@ -181,8 +181,7 @@ def home():
 def saveconfig():
     global config, folders_to_create
 
-    with open(".config/config.json", encoding="utf-8") as f:
-        config = json.load(f)
+    config = get_config()
 
     # Retrieve form data
     new_config = request.get_json()
@@ -256,9 +255,7 @@ def saveconfig():
         except (TypeError, ValueError):
             pass
 
-    with open(".config/config.json", "w", encoding="utf-8") as json_file:
-        json.dump(config, json_file, indent=4)
-
+    save_config(config)
 
     if obs_reload:
         reload_obs()
@@ -301,8 +298,8 @@ def complete_save_config():
     config = update_gridsize(config, new_height, new_width)
     config["front"]["height"] = new_height
     config["front"]["width"] = new_width
-    with open(".config/config.json", "w", encoding="utf-8") as json_file:
-        json.dump(config, json_file, indent=4)
+
+    save_config(config)
 
     log.success("Config saved successfully")
     return jsonify({"success": True})
@@ -315,8 +312,7 @@ def save_single_button():
     button_index = int(data.get("location_Id"))
     button_content = data.get("content")
 
-    with open(".config/config.json", encoding="utf-8") as f:
-        config = json.load(f)
+    config = get_config()
 
     button_folderName = list(config["front"]["buttons"])[button_folder]
     log.debug(
@@ -329,9 +325,7 @@ def save_single_button():
         + str(config["front"]["buttons"][button_folderName][button_index])
     )
 
-    with open(".config/config.json", "w", encoding="utf-8") as json_file:
-        json.dump(config, json_file, indent=4)
-        set_global_variable("config", config)
+    save_config(config)
 
     log.success("Button saved successfully")
     return jsonify({"success": True})
@@ -343,8 +337,7 @@ def save_buttons_only():
     global folders_to_create
 
     # Get current config first
-    with open(".config/config.json", encoding="utf-8") as f:
-        config = json.load(f)
+    config = get_config()
 
     # Retrieve form data
     new_config = request.get_json()
@@ -370,16 +363,13 @@ def save_buttons_only():
 def get_config_route():
     global folders_to_create, config
 
-    with open(".config/config.json", encoding="utf-8") as f:
-        config = json.load(f)
+    config = get_config()
 
     config = create_folders(config, folders_to_create)
     folders_to_create = []
     set_global_variable("config", config)
 
-    with open(".config/config.json", "w", encoding="utf-8") as json_file:
-        json.dump(config, json_file, indent=4)
-        set_global_variable("config", config)
+    save_config(config)
 
     return jsonify(config)
 
@@ -477,8 +467,6 @@ def get_config_file(directory, filename):
 @socketio.on("connect")
 def socketio_connect():
     log.info("Socketio client connected")
-    with open(".config/config.json", encoding="utf-8") as f:
-        config = json.load(f)
 
 @socketio.event
 def send(data):


### PR DESCRIPTION
Instead of manipulating the ```config.json``` file directly, use the available ```get_config``` and ```save_config``` functions.

Note: this MR removes the code without effect in ```socketio_connect()``` in ```app/server.py```. 
Feel free to modify it to update the _global_ ```config``` variable.