### PR TITLE
Add support for arbitrary hotkeys

### DIFF
--- a/app/buttons/commands.py
+++ b/app/buttons/commands.py
@@ -30,7 +30,7 @@ from . import color_picker
 from . import system
 
 
-def handle_command(message=None, registered_hotkeys=None):
+def handle_command(message=None):
     global all_func
 
     command_arguments = message
@@ -101,8 +101,7 @@ def handle_command(message=None, registered_hotkeys=None):
 
     elif message.startswith("/key"):
         key = message.removeprefix('/key').strip()
-        if key in registered_hotkeys:
-            keyboard.send(key)
+        keyboard.send(key)
 
     elif message.startswith("/restartexplorer"):
         subprocess.Popen("taskkill /f /im explorer.exe", shell=True)

--- a/app/buttons/commands.py
+++ b/app/buttons/commands.py
@@ -30,8 +30,7 @@ from . import color_picker
 from . import system
 
 
-
-def handle_command(message=None):
+def handle_command(message=None, registered_hotkeys=None):
     global all_func
 
     command_arguments = message
@@ -101,8 +100,9 @@ def handle_command(message=None):
             pyautogui.press("CTRL")
 
     elif message.startswith("/key"):
-        key = message.replace("/key", "", 1).strip()
-        pyautogui.press(key)
+        key = message.removeprefix('/key').strip()
+        if key in registered_hotkeys:
+            keyboard.send(key)
 
     elif message.startswith("/restartexplorer"):
         subprocess.Popen("taskkill /f /im explorer.exe", shell=True)

--- a/app/server.py
+++ b/app/server.py
@@ -68,7 +68,6 @@ app.config["SECRET_KEY"] = get_config()["settings"]["flask_secret_key"]
 
 socketio = SocketIO(app)
 
-registered_hotkeys = set()
 
 @app.route("/usage", methods=["POST"])
 def usage():
@@ -135,14 +134,6 @@ def get_svgs():
 @app.route("/")
 def home():
     config = get_config(save_updated_config=True)
-    
-    global registered_hotkeys
-    registered_hotkeys = {
-        button['message'].removeprefix('/key').strip()
-        for folders in config['front']['buttons'].values() 
-        for button in folders 
-        if 'message' in button.keys() and button['message'].startswith('/key')
-    }
 
     with open("webdeck/commands.json", encoding="utf-8") as f:
         commands = json.load(f)
@@ -484,7 +475,7 @@ def send(data):
 @socketio.on("message_from_socket")
 def send_data_socketio(message):
     try:
-        result = command(message=message, registered_hotkeys=registered_hotkeys)
+        result = command(message=message)
     except Exception as e:
         log.exception(e, "An error occurred while handling a command")
         return jsonify({"success": False, "message": str(e)})
@@ -506,7 +497,7 @@ def send_data_socketio(message):
 @app.route("/send-data", methods=["POST"])
 def send_data_route():
     try:
-        result = command(message=request.get_json()["message"], registered_hotkeys=registered_hotkeys)
+        result = command(message=request.get_json()["message"])
     except Exception as e:
         log.exception(e, "An error occurred while handling a command")
         return jsonify({"success": False, "message": str(e)})

--- a/app/server.py
+++ b/app/server.py
@@ -68,6 +68,7 @@ app.config["SECRET_KEY"] = get_config()["settings"]["flask_secret_key"]
 
 socketio = SocketIO(app)
 
+registered_hotkeys = set()
 
 @app.route("/usage", methods=["POST"])
 def usage():
@@ -134,6 +135,14 @@ def get_svgs():
 @app.route("/")
 def home():
     config = get_config(save_updated_config=True)
+    
+    global registered_hotkeys
+    registered_hotkeys = {
+        button['message'].removeprefix('/key').strip()
+        for folders in config['front']['buttons'].values() 
+        for button in folders 
+        if 'message' in button.keys() and button['message'].startswith('/key')
+    }
 
     with open("webdeck/commands.json", encoding="utf-8") as f:
         commands = json.load(f)
@@ -475,7 +484,7 @@ def send(data):
 @socketio.on("message_from_socket")
 def send_data_socketio(message):
     try:
-        result = command(message=message)
+        result = command(message=message, registered_hotkeys=registered_hotkeys)
     except Exception as e:
         log.exception(e, "An error occurred while handling a command")
         return jsonify({"success": False, "message": str(e)})
@@ -497,7 +506,7 @@ def send_data_socketio(message):
 @app.route("/send-data", methods=["POST"])
 def send_data_route():
     try:
-        result = command(message=request.get_json()["message"])
+        result = command(message=request.get_json()["message"], registered_hotkeys=registered_hotkeys)
     except Exception as e:
         log.exception(e, "An error occurred while handling a command")
         return jsonify({"success": False, "message": str(e)})


### PR DESCRIPTION
Key buttons now support hotkey combinations like ```ctrl+shift+r``` or ```CTRL+esc``` or ```Menu```.

For all supported key combinations, see [keyboard`s ](https://github.com/boppreh/keyboard/blob/d4fbad6fae8a6345d0afa53b853a012617a43cd8/keyboard/_canonical_names.py#L12) canonical names list. 

Also, the implementation will only execute key combinations that were part of the server's config file instead of openly feeding a client's request string directly into what is effectively a keyboard emulation engine connected to the internet. 

This mechanism might have issues with different configured keyboard layouts, still. 
