### PR TITLE
Add check for Wayland so the server doesn't crash

### DIFF
--- a/app/buttons/window/close_window.py
+++ b/app/buttons/window/close_window.py
@@ -1,10 +1,11 @@
-from app.utils.platform import is_windows, is_linux
+from app.utils.platform import is_windows, is_linux, is_wayland
 
 import subprocess
 if is_windows:
     import win32gui
     import win32con
-from app.utils.get_process_path import xdotool
+if not is_wayland:
+    from app.utils.get_process_path import xdotool
 from app.utils.logger import log
 
 
@@ -23,10 +24,11 @@ def close_window(window):
     elif is_linux:
         # While using Linux, the window name is the window ID
         window_id = window
-        if subprocess.run([xdotool, "windowclose", window_id]).returncode != 0:
-            log.warning(f"Window with ID '{window_id}' not found or already closed")
-            raise RuntimeError(f"Window with ID '{window_id}' not found or already closed")
-        log.success(f"Window with ID '{window_id}' has been closed")
+        if not is_wayland:
+            if subprocess.run([xdotool, "windowclose", window_id]).returncode != 0:
+                log.warning(f"Window with ID '{window_id}' not found or already closed")
+                raise RuntimeError(f"Window with ID '{window_id}' not found or already closed")
+            log.success(f"Window with ID '{window_id}' has been closed")
     
     else:
         log.error("This command is not implemented for this platform.")

--- a/app/buttons/window/get_focused.py
+++ b/app/buttons/window/get_focused.py
@@ -1,7 +1,8 @@
-from app.utils.platform import is_windows, is_linux
+from app.utils.platform import is_windows, is_linux, is_wayland
 
 if is_windows: import win32gui
-from app.utils.get_process_path import xdotool
+if not is_wayland:
+    from app.utils.get_process_path import xdotool
 from app.utils.logger import log
 import subprocess
 

--- a/app/utils/get_process_path.py
+++ b/app/utils/get_process_path.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from .platform import is_linux
+from .platform import is_linux, is_wayland
 
 
 def get_process_path(process_name):
@@ -17,6 +17,7 @@ def get_process_path(process_name):
         raise NotImplementedError("This function is not implemented for this platform")
 
 
-xdotool = get_process_path("xdotool")
-copyq = get_process_path("copyq")
+if not is_wayland:
+    xdotool = get_process_path("xdotool")
+    copyq = get_process_path("copyq")
 xclip = get_process_path("xclip")

--- a/app/utils/platform.py
+++ b/app/utils/platform.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 def platform(lower=False):
@@ -30,11 +31,15 @@ def is_linux():
 def is_macos():
     return platform() == 'macOS'
 
+def is_wayland():
+    return os.environ.get("XDG_SESSION_TYPE") == "wayland"
+
 
 is_windows = is_windows()
 is_win = is_windows
 
 is_linux = is_linux()
+is_wayland = is_wayland()
 
 is_macos = is_macos()
 is_mac = is_macos


### PR DESCRIPTION
This is a small hotfix so the server doesn't crash when using it on Wayland. Ideally you'd (or maybe i will) implement alternatives like `ydotool` and something else than copyq so it doesn't crash but still work. As of the nature of Wayland window management will not work using ydotool sadly. Alternative might be sending the keystrokes for Alt+F4.