### PR TITLE
Fix for the TODO on set_microphone_by_name

### DIFF
--- a/app/buttons/audio/set_system_mic.py
+++ b/app/buttons/audio/set_system_mic.py
@@ -1,8 +1,11 @@
-import subprocess
-
+import comtypes
+from pycaw.pycaw import AudioUtilities
+from pycaw.constants import EDataFlow, ERole
 
 def set_microphone_by_name(name):
-    # TODO: (not working rn)
-    # Find the recording device with the specified name
-    command = f"PowerShell -Command \"Get-WmiObject Win32_SoundDevice | Where-Object {{ $_.Name -like '*{name}*' -and $_.ConfigManagerErrorCode -eq 0 }} | Select-Object -First 1 | Invoke-CimMethod -MethodName SetDefault\""
-    subprocess.run(command, shell=True)
+    comtypes.CoInitialize()
+    devices = AudioUtilities.GetAllDevices(data_flow=EDataFlow.eCapture.value)
+    for device in devices:
+        if device.FriendlyName == name:
+            AudioUtilities.SetDefaultDevice(device.id, roles=[ERole.eCommunications])
+            return None

--- a/app/buttons/audio/set_system_speaker.py
+++ b/app/buttons/audio/set_system_speaker.py
@@ -1,27 +1,10 @@
-import pyaudio
-import win32api
-import win32con
+import comtypes
+from pycaw.pycaw import AudioUtilities
+from pycaw.constants import EDataFlow
 
-
-p = pyaudio.PyAudio()
 def set_speakers_by_name(speakers_name):
-    # TODO: (not working rn)
-    device_count = p.get_device_count()
-
-    for i in range(device_count):
-        device_info = p.get_device_info_by_index(i)
-        if device_info["name"].lower().find(speakers_name.lower()) != -1:
-            # Select the found audio device
-            win32api.SendMessage(
-                win32con.HWND_BROADCAST,
-                win32con.WM_APPCOMMAND,
-                0,
-                win32api.LPARAM(0x30292),
-            )
-            win32api.SendMessage(
-                win32con.HWND_BROADCAST,
-                win32con.WM_APPCOMMAND,
-                0,
-                win32api.LPARAM(0x30290 + i),
-            )
-            break
+    comtypes.CoInitialize()
+    devices = AudioUtilities.GetAllDevices(data_flow=EDataFlow.eRender.value)
+    for device in devices:
+        if device.FriendlyName == speakers_name:
+            AudioUtilities.SetDefaultDevice(device.id)


### PR DESCRIPTION
This PR fixes the todo on setting default input device by name using pycaw. Same as for output by with roles=[ERole.eCommunications] on calling SetDefaultDevice.